### PR TITLE
Fix: download correct binarized dataset

### DIFF
--- a/download_mnist.py
+++ b/download_mnist.py
@@ -18,6 +18,6 @@ if __name__ == '__main__':
     subdatasets = ['train', 'valid', 'test']
     for subdataset in subdatasets:
         filename = 'binarized_mnist_{}.amat'.format(subdataset)
+        url = 'http://www.cs.toronto.edu/~larocheh/public/datasets/binarized_mnist/binarized_mnist_{}.amat'.format(subdatasets)
         local_filename = os.path.join(config.DATASETS_DIR, "BinaryMNIST", filename)
-        urllib.urlretrieve("http://www.cs.toronto.edu/~larocheh/public/datasets/binarized_mnist/binarized_mnist_train.amat",
-                           local_filename)
+        urllib.urlretrieve(url, local_filename)


### PR DESCRIPTION
The script downloaded the training dataset 3 times and stored the same dataset as train, valid and testset.

As a result, the evaluation and final log-likelihood reports for FixedBinarizedMNIST experiments were not performed on the testset, but on the training set again!
